### PR TITLE
testcase updates #180 #181 (fwp test cases are merged on previous PR #182)

### DIFF
--- a/clarity/Clarinet.toml
+++ b/clarity/Clarinet.toml
@@ -1,10 +1,93 @@
 [project]
 name = "alex-v1"
 requirements = []
+[contracts.alex-reserve-pool]
+path = "contracts/pool/alex-reserve-pool.clar"
+depends_on = ["token-alex", "token-usda", "open-oracle", "math-fixed-point", "trait-ownable"]
 
-[contracts.trait-ownable]
-path = "contracts/traits/trait-ownable.clar"
+[contracts.alex-vault]
+path = "contracts/alex-vault.clar"
+depends_on = ["trait-vault", "trait-sip-010", "trait-flash-loan-user", "math-fixed-point", "trait-ownable"]
+
+[contracts.collateral-rebalancing-pool]
+path = "contracts/pool/collateral-rebalancing-pool.clar"
+depends_on = ["trait-sip-010", "trait-yield-token", "trait-vault", "math-fixed-point", "weighted-equation", "open-oracle", "fixed-weight-pool", "token-usda", "token-alex", "alex-reserve-pool", "yield-token-pool"]
+
+[contracts.fixed-weight-pool]
+path = "contracts/pool/fixed-weight-pool.clar"
+depends_on = ["trait-sip-010", "trait-pool-token", "trait-vault", "math-fixed-point", "weighted-equation", "token-alex", "open-oracle", "alex-reserve-pool", "token-usda", "trait-multisig-vote"]
+
+[contracts.flash-loan-user-margin-usda-wbtc-59760]
+path = "contracts/flash-loan-user-margin-usda-wbtc-59760.clar"
+depends_on = ["token-usda", "token-wbtc", "yield-wbtc-59760", "key-wbtc-59760-usda"]
+
+[contracts.fwp-wbtc-usda-50-50]
+path = "contracts/pool-token/fwp-wbtc-usda-50-50.clar"
+depends_on = ["trait-sip-010", "trait-pool-token", "trait-ownable"]
+
+[contracts.key-wbtc-59760-usda]
+path = "contracts/key-token/key-wbtc-59760-usda.clar"
+depends_on = ["trait-sip-010", "trait-yield-token", "token-wbtc", "trait-ownable"]
+
+[contracts.key-wbtc-79760-usda]
+path = "contracts/key-token/key-wbtc-79760-usda.clar"
+depends_on = ["trait-sip-010", "trait-yield-token", "token-wbtc", "trait-ownable"]
+
+[contracts.liquidity-bootstrapping-pool]
+path = "contracts/pool/liquidity-bootstrapping-pool.clar"
+depends_on = ["trait-sip-010", "trait-pool-token", "trait-vault", "math-fixed-point", "weighted-equation", "token-alex", "open-oracle", "alex-reserve-pool", "token-usda", "fixed-weight-pool", "trait-multisig-vote"]
+
+[contracts.math-fixed-point]
+path = "contracts/lib/math-fixed-point.clar"
+depends_on = ["math-log-exp"]
+
+[contracts.math-log-exp]
+path = "contracts/lib/math-log-exp.clar"
 depends_on = []
+
+[contracts.math-new-lib]
+path = "contracts/new-lib/math-new-lib.clar"
+depends_on = ["math-new-log-exp"]
+
+[contracts.math-new-log-exp]
+path = "contracts/new-lib/math-new-log-exp.clar"
+depends_on = []
+
+[contracts.multisig-crp-wbtc-59760-usda]
+path = "contracts/multisig/multisig-crp-wbtc-59760-usda.clar"
+depends_on = ["yield-wbtc-59760", "key-wbtc-59760-usda", "token-wbtc", "token-usda", "trait-sip-010"]
+
+[contracts.multisig-crp-wbtc-79760-usda]
+path = "contracts/multisig/multisig-crp-wbtc-79760-usda.clar"
+depends_on = ["yield-wbtc-79760", "key-wbtc-79760-usda", "token-wbtc", "token-usda", "trait-sip-010"]
+
+[contracts.multisig-fwp-wbtc-usda-50-50]
+path = "contracts/multisig/multisig-fwp-wbtc-usda-50-50.clar"
+depends_on = []
+
+[contracts.multisig-ytp-yield-wbtc-59760-wbtc]
+path = "contracts/multisig/multisig-ytp-yield-wbtc-59760-wbtc.clar"
+depends_on = ["ytp-yield-wbtc-59760-wbtc", "trait-yield-token", "trait-sip-010", "yield-token-pool", "yield-wbtc-59760"]
+
+[contracts.multisig-ytp-yield-wbtc-79760-wbtc]
+path = "contracts/multisig/multisig-ytp-yield-wbtc-59760-wbtc.clar"
+depends_on = ["ytp-yield-wbtc-79760-wbtc", "trait-yield-token", "trait-sip-010", "yield-token-pool", "yield-wbtc-79760"]
+
+[contracts.open-oracle]
+path = "contracts/open-oracle.clar"
+depends_on = ["trait-yield-token", "trait-oracle", "trait-sip-010"]
+
+[contracts.token-alex]
+path = "contracts/token/token-alex.clar"
+depends_on = ["trait-pool-token", "trait-ownable"]
+
+[contracts.token-usda]
+path = "contracts/token/token-usda.clar"
+depends_on = ["trait-pool-token", "trait-ownable"]
+
+[contracts.token-wbtc]
+path = "contracts/token/token-wbtc.clar"
+depends_on = ["trait-pool-token", "trait-ownable"]
 
 [contracts.trait-flash-loan-user]
 path = "contracts/traits/trait-flash-loan-user.clar"
@@ -16,6 +99,10 @@ depends_on = ["trait-sip-010"]
 
 [contracts.trait-oracle]
 path = "contracts/traits/trait-oracle.clar"
+depends_on = []
+
+[contracts.trait-ownable]
+path = "contracts/traits/trait-ownable.clar"
 depends_on = []
 
 [contracts.trait-pool-token]
@@ -34,14 +121,6 @@ depends_on = ["trait-sip-010", "trait-flash-loan-user"]
 path = "contracts/traits/trait-yield-token.clar"
 depends_on = []
 
-[contracts.math-fixed-point]
-path = "contracts/lib/math-fixed-point.clar"
-depends_on = ["math-log-exp"]
-
-[contracts.math-log-exp]
-path = "contracts/lib/math-log-exp.clar"
-depends_on = []
-
 [contracts.weighted-equation]
 path = "contracts/equations/weighted-equation.clar"
 depends_on = ["math-fixed-point"]
@@ -50,17 +129,9 @@ depends_on = ["math-fixed-point"]
 path = "contracts/equations/yield-token-equation.clar"
 depends_on = ["math-fixed-point"]
 
-[contracts.token-alex]
-path = "contracts/token/token-alex.clar"
-depends_on = ["trait-pool-token", "trait-ownable"]
-
-[contracts.token-usda]
-path = "contracts/token/token-usda.clar"
-depends_on = ["trait-pool-token", "trait-ownable"]
-
-[contracts.token-wbtc]
-path = "contracts/token/token-wbtc.clar"
-depends_on = ["trait-pool-token", "trait-ownable"]
+[contracts.yield-token-pool]
+path = "contracts/pool/yield-token-pool.clar"
+depends_on = ["trait-sip-010", "trait-pool-token", "trait-vault", "trait-flash-loan-user", "math-fixed-point", "yield-token-equation", "trait-yield-token", "open-oracle", "token-alex", "token-usda", "fixed-weight-pool", "alex-reserve-pool", "trait-multisig-vote"]
 
 [contracts.yield-wbtc-59760]
 path = "contracts/yield-token/yield-wbtc-59760.clar"
@@ -77,67 +148,3 @@ depends_on = ["trait-sip-010", "trait-pool-token", "trait-ownable"]
 [contracts.ytp-yield-wbtc-79760-wbtc]
 path = "contracts/pool-token/ytp-yield-wbtc-79760-wbtc.clar"
 depends_on = ["trait-sip-010", "trait-pool-token", "trait-ownable"]
-
-[contracts.fwp-wbtc-usda-50-50]
-path = "contracts/pool-token/fwp-wbtc-usda-50-50.clar"
-depends_on = ["trait-sip-010", "trait-pool-token", "trait-ownable"]
-
-[contracts.key-wbtc-59760-usda]
-path = "contracts/key-token/key-wbtc-59760-usda.clar"
-depends_on = ["trait-sip-010", "trait-yield-token", "token-wbtc", "trait-ownable"]
-
-[contracts.key-wbtc-79760-usda]
-path = "contracts/key-token/key-wbtc-79760-usda.clar"
-depends_on = ["trait-sip-010", "trait-yield-token", "token-wbtc", "trait-ownable"]
-
-[contracts.alex-reserve-pool]
-path = "contracts/pool/alex-reserve-pool.clar"
-depends_on = ["token-alex", "token-usda", "open-oracle", "math-fixed-point", "trait-ownable"]
-
-[contracts.alex-vault]
-path = "contracts/alex-vault.clar"
-depends_on = ["trait-vault", "trait-sip-010", "trait-flash-loan-user", "math-fixed-point", "trait-ownable"]
-
-[contracts.open-oracle]
-path = "contracts/open-oracle.clar"
-depends_on = ["trait-yield-token", "trait-oracle", "trait-sip-010"]
-
-[contracts.fixed-weight-pool]
-path = "contracts/pool/fixed-weight-pool.clar"
-depends_on = ["trait-sip-010", "trait-pool-token", "trait-vault", "math-fixed-point", "weighted-equation", "token-alex", "open-oracle", "alex-reserve-pool", "token-usda", "trait-multisig-vote"]
-
-[contracts.yield-token-pool]
-path = "contracts/pool/yield-token-pool.clar"
-depends_on = ["trait-sip-010", "trait-pool-token", "trait-vault", "trait-flash-loan-user", "math-fixed-point", "yield-token-equation", "trait-yield-token", "open-oracle", "token-alex", "token-usda", "fixed-weight-pool", "alex-reserve-pool", "trait-multisig-vote"]
-
-[contracts.collateral-rebalancing-pool]
-path = "contracts/pool/collateral-rebalancing-pool.clar"
-depends_on = ["trait-sip-010", "trait-yield-token", "trait-vault", "math-fixed-point", "weighted-equation", "open-oracle", "fixed-weight-pool", "token-usda", "token-alex", "alex-reserve-pool", "yield-token-pool"]
-
-[contracts.liquidity-bootstrapping-pool]
-path = "contracts/pool/liquidity-bootstrapping-pool.clar"
-depends_on = ["trait-sip-010", "trait-pool-token", "trait-vault", "math-fixed-point", "weighted-equation", "token-alex", "open-oracle", "alex-reserve-pool", "token-usda", "fixed-weight-pool", "trait-multisig-vote"]
-
-[contracts.flash-loan-user-margin-usda-wbtc-59760]
-path = "contracts/flash-loan-user-margin-usda-wbtc-59760.clar"
-depends_on = ["token-usda", "token-wbtc", "yield-wbtc-59760", "key-wbtc-59760-usda"]
-
-[contracts.multisig-fwp-wbtc-usda-50-50]
-path = "contracts/multisig/multisig-fwp-wbtc-usda-50-50.clar"
-depends_on = []
-
-[contracts.multisig-ytp-yield-wbtc-59760-wbtc]
-path = "contracts/multisig/multisig-ytp-yield-wbtc-59760-wbtc.clar"
-depends_on = ["ytp-yield-wbtc-59760-wbtc", "trait-yield-token", "trait-sip-010", "yield-token-pool", "yield-wbtc-59760"]
-
-[contracts.multisig-ytp-yield-wbtc-79760-wbtc]
-path = "contracts/multisig/multisig-ytp-yield-wbtc-59760-wbtc.clar"
-depends_on = ["ytp-yield-wbtc-79760-wbtc", "trait-yield-token", "trait-sip-010", "yield-token-pool", "yield-wbtc-79760"]
-
-[contracts.multisig-crp-wbtc-59760-usda]
-path = "contracts/multisig/multisig-crp-wbtc-59760-usda.clar"
-depends_on = ["yield-wbtc-59760", "key-wbtc-59760-usda", "token-wbtc", "token-usda", "trait-sip-010"]
-
-[contracts.multisig-crp-wbtc-79760-usda]
-path = "contracts/multisig/multisig-crp-wbtc-79760-usda.clar"
-depends_on = ["yield-wbtc-79760", "key-wbtc-79760-usda", "token-wbtc", "token-usda", "trait-sip-010"]

--- a/clarity/contracts/equations/weighted-equation.clar
+++ b/clarity/contracts/equations/weighted-equation.clar
@@ -17,7 +17,7 @@
 ;; for testing only
 (define-constant MAX_IN_RATIO (* u9 (pow u10 u7)))
 (define-constant MAX_OUT_RATIO (* u9 (pow u10 u7)))
-
+(define-constant TOLERANCE u10)
 ;; data maps and vars
 ;;
 
@@ -58,9 +58,11 @@
                 (bound (unwrap-panic (contract-call? .math-log-exp get-exp-bound)))
                 (exponent (if (< uncapped-exponent bound) uncapped-exponent bound))
                 (power (unwrap-panic (pow-up base exponent)))
-                (complement (unwrap-panic (sub-fixed ONE_8 power)))
+                ;;(complement (unwrap-panic (sub-fixed ONE_8 power)))
             )
-            (mul-down balance-y complement)
+            (if (> ONE_8 (+ TOLERANCE power)) (mul-down balance-y (unwrap-panic (sub-fixed ONE_8 power))) (ok u0))  
+            ;;(mul-down balance-y complement)
+            
         ) 
     )    
 )
@@ -83,9 +85,10 @@
                 (bound (unwrap-panic (contract-call? .math-log-exp get-exp-bound)))
                 (exponent (if (< uncapped-exponent bound) uncapped-exponent bound))
                 (power (unwrap-panic (pow-down base exponent)))
-                (ratio (unwrap-panic (sub-fixed power ONE_8)))
+                ;;(ratio (unwrap-panic (sub-fixed power ONE_8)))
             )
-            (mul-down balance-x ratio)
+            (if (> power (+ TOLERANCE ONE_8)) (mul-down balance-x (unwrap-panic (sub-fixed power ONE_8))) (ok u0)) 
+            ;;(mul-down balance-x ratio)
         )
     )
 )
@@ -113,7 +116,8 @@
                     (base (unwrap-panic (div-up spot price)))
                     (power (unwrap-panic (pow-down base weight-y)))                
                 )
-                (mul-up balance-x (unwrap-panic (sub-fixed power ONE_8)))            
+                ;;(mul-up balance-x (unwrap-panic (sub-fixed power ONE_8)))   
+                (if (> power (+ TOLERANCE ONE_8)) (mul-up balance-x (unwrap-panic (sub-fixed power ONE_8))) (ok u0))    
             )
         )
     )   
@@ -135,7 +139,9 @@
                     (base (unwrap-panic (div-up spot price)))
                     (power (unwrap-panic (pow-down base weight-y)))
                 )
-                (mul-up balance-y (unwrap-panic (sub-fixed ONE_8 power)))
+                ;;(mul-up balance-y (unwrap-panic (sub-fixed ONE_8 power)))
+                (if (> ONE_8 (+ TOLERANCE power)) (mul-down balance-y (unwrap-panic (sub-fixed ONE_8 power))) (ok u0))  
+
             )
         )
     )   

--- a/clarity/contracts/equations/yield-token-equation.clar
+++ b/clarity/contracts/equations/yield-token-equation.clar
@@ -75,7 +75,7 @@
             (y-pow (unwrap-panic (pow-down balance-y t-comp)))
             (y-dy-pow (unwrap-panic (pow-up (unwrap-panic (sub-fixed balance-y dy)) t-comp)))
             (term (unwrap-panic (sub-fixed (unwrap-panic (add-fixed x-pow y-pow)) y-dy-pow)))            
-        )        
+        )       
         (sub-fixed (unwrap-panic (pow-down term t-comp-num)) balance-x)         
     )  
   )

--- a/clarity/contracts/equations/yield-token-equation.clar
+++ b/clarity/contracts/equations/yield-token-equation.clar
@@ -19,7 +19,7 @@
 ;; for testing only
 (define-constant MAX_IN_RATIO (* u5 (pow u10 u7)))
 (define-constant MAX_OUT_RATIO (* u5 (pow u10 u7)))
-
+(define-constant TOLERANCE u10)
 ;; data maps and vars
 ;;
 
@@ -49,8 +49,9 @@
             (y-pow (unwrap-panic (pow-down balance-y t-comp)))
             (x-dx-pow (unwrap-panic (pow-down (unwrap-panic (add-fixed balance-x dx)) t-comp)))
             (term (unwrap-panic (sub-fixed (unwrap-panic (add-fixed x-pow y-pow)) x-dx-pow)))
+            (pow-term (unwrap-panic (pow-down term t-comp-num)))
         )     
-        (sub-fixed balance-y (unwrap-panic (pow-down term t-comp-num)))
+        (if (> balance-y (+ TOLERANCE pow-term)) (sub-fixed balance-y pow-term) (ok u0))  
     )    
   )
 )
@@ -75,8 +76,9 @@
             (y-pow (unwrap-panic (pow-down balance-y t-comp)))
             (y-dy-pow (unwrap-panic (pow-up (unwrap-panic (sub-fixed balance-y dy)) t-comp)))
             (term (unwrap-panic (sub-fixed (unwrap-panic (add-fixed x-pow y-pow)) y-dy-pow)))            
-        )       
-        (sub-fixed (unwrap-panic (pow-down term t-comp-num)) balance-x)         
+            (pow-term (unwrap-panic (pow-down term t-comp-num)))
+        )
+        (if (> pow-term (+ TOLERANCE balance-x)) (sub-fixed pow-term balance-x) (ok u0))       
     )  
   )
 )

--- a/clarity/contracts/lib/math-fixed-point.clar
+++ b/clarity/contracts/lib/math-fixed-point.clar
@@ -133,18 +133,18 @@
         )
         
         ;;(add-fixed raw max-error)
-        (if (>= a ONE_8)  (round raw TOLERANCE_CONSTANT) (add-fixed raw max-error))
+        (if (>= a ONE_8)  (round-for-up raw TOLERANCE_CONSTANT) (add-fixed raw max-error))
     )
 )
 
-(define-read-only (round (a uint) (tolerance uint))
+(define-read-only (round-for-up (a uint) (tolerance uint))
     (begin
     (if (is-eq (mod a tolerance) u0) (ok a)
         (let
             (
-                (temp (/ a tolerance))
-                (temp2 (+ temp u1))
-                (rounded (* temp2 tolerance))
+                (divided (/ a tolerance))
+                (new-value (+ divided u1))
+                (rounded (* new-value tolerance))
             )
         (ok rounded)
         )

--- a/clarity/contracts/lib/math-fixed-point.clar
+++ b/clarity/contracts/lib/math-fixed-point.clar
@@ -133,7 +133,7 @@
         )
         
         ;;(add-fixed raw max-error)
-        (if (and (>= a ONE_8) (round raw TOLERANCE_CONSTANT) (add-fixed raw max-error))
+        (if (>= a ONE_8)  (round raw TOLERANCE_CONSTANT) (add-fixed raw max-error))
     )
 )
 

--- a/clarity/contracts/lib/math-fixed-point.clar
+++ b/clarity/contracts/lib/math-fixed-point.clar
@@ -20,6 +20,7 @@
 ;; which could aggregate to about 8 x 0.5 * 10^-8 = 4 * 10^-8 relative error 
 ;; (i.e. the last digit of the result may be completely lost to this error).
 (define-constant MAX_POW_RELATIVE_ERROR u4) 
+(define-constant TOLERANCE_CONSTANT u10000)
 
 ;; public functions
 ;;
@@ -128,7 +129,25 @@
         (
             (raw (unwrap-panic (contract-call? .math-log-exp pow-fixed a b)))
             (max-error (+ u1 (unwrap-panic (mul-up raw MAX_POW_RELATIVE_ERROR))))
+            (prv-result (unwrap-panic (add-fixed raw max-error)))
         )
-        (add-fixed raw max-error)
+        
+        ;;(add-fixed raw max-error)
+        (if (and (>= a ONE_8) (round raw TOLERANCE_CONSTANT) (add-fixed raw max-error))
+    )
+)
+
+(define-read-only (round (a uint) (tolerance uint))
+    (begin
+    (if (is-eq (mod a tolerance) u0) (ok a)
+        (let
+            (
+                (temp (/ a tolerance))
+                (temp2 (+ temp u1))
+                (rounded (* temp2 tolerance))
+            )
+        (ok rounded)
+        )
+    )
     )
 )

--- a/clarity/contracts/new-lib/math-new-lib.clar
+++ b/clarity/contracts/new-lib/math-new-lib.clar
@@ -1,0 +1,134 @@
+
+;; math-fixed-point
+;; Fixed Point Math
+;; following https://github.com/balancer-labs/balancer-v2-monorepo/blob/master/pkg/solidity-utils/contracts/math/FixedPoint.sol
+
+;; TODO: overflow causes runtime error, should handle before operation rather than after
+
+;; constants
+;;
+(define-constant ONE_10 (pow u10 u10)) ;; 8 decimal places
+(define-constant ERR-SCALE-UP-OVERFLOW (err u5001))
+(define-constant ERR-SCALE-DOWN-OVERFLOW (err u5002))
+(define-constant ERR-ADD-OVERFLOW (err u5003))
+(define-constant ERR-SUB-OVERFLOW (err u5004))
+(define-constant ERR-MUL-OVERFLOW (err u5005))
+(define-constant ERR-DIV-OVERFLOW (err u5006))
+(define-constant ERR-POW-OVERFLOW (err u5007))
+
+;; With 8 fixed digits you would have a maximum error of 0.5 * 10^-10 in each entry, 
+;; which could aggregate to about 10 x 0.5 * 10^-10 = 5 * 10^-10 relative error 
+;; (i.e. the last digit of the result may be completely lost to this error).
+(define-constant MAX_POW_RELATIVE_ERROR u5) 
+
+;; public functions
+;;
+
+(define-read-only (get_one)
+    (ok ONE_10)
+)
+
+(define-read-only (scale-up (a uint))
+    (let
+        (
+            (r (* a ONE_10))
+        )
+        (asserts! (is-eq (/ r ONE_10) a) ERR-SCALE-UP-OVERFLOW)
+        (ok r)
+    )
+)
+
+(define-read-only (scale-down (a uint))
+  (let
+    ((r (/ a ONE_10)))
+    (asserts! (is-eq (* r ONE_10) a) ERR-SCALE-DOWN-OVERFLOW)
+    (ok r)
+ )
+)
+
+(define-read-only (add-fixed (a uint) (b uint))
+    (let
+        (
+            (c (+ a b))
+        )
+        (asserts! (>= c a) ERR-ADD-OVERFLOW)
+        (ok c)
+    )
+)
+
+(define-read-only (sub-fixed (a uint) (b uint))
+    (let
+        ()
+        (asserts! (<= b a) ERR-SUB-OVERFLOW)
+        (ok (- a b))
+    )
+)
+
+(define-read-only (mul-down (a uint) (b uint))
+    (let
+        (
+            (product (* a b))
+        )
+        (ok (/ product ONE_10))
+    )
+)
+
+
+(define-read-only (mul-up (a uint) (b uint))
+    (let
+        (
+            (product (* a b))
+       )
+        (if (is-eq product u0)
+            (ok u0)
+            (ok (+ u1 (/ (- product u1) ONE_10)))
+       )
+   )
+)
+
+(define-read-only (div-down (a uint) (b uint))
+    (let
+        (
+            (a-inflated (* a ONE_10))
+       )
+        (if (is-eq a u0)
+            (ok u0)
+            (ok (/ a-inflated b))
+       )
+   )
+)
+
+(define-read-only (div-up (a uint) (b uint))
+    (let
+        (
+            (a-inflated (* a ONE_10))
+       )
+        (if (is-eq a u0)
+            (ok u0)
+            (ok (+ u1 (/ (- a-inflated u1) b)))
+       )
+   )
+)
+
+(define-read-only (pow-down (a uint) (b uint))    
+    (let
+        (
+            (raw (unwrap-panic (contract-call? .math-new-log-exp pow-fixed a b)))
+            (max-error (+ u1 (unwrap-panic (mul-up raw MAX_POW_RELATIVE_ERROR))))
+        )
+        (if (< raw max-error)
+            (ok u0)
+            (sub-fixed raw max-error)
+        )
+    )
+)
+
+(define-read-only (pow-up (a uint) (b uint))
+    (let
+        (
+            (raw (unwrap-panic (contract-call? .math-new-log-exp pow-fixed a b)))
+            (max-error (+ u1 (unwrap-panic (mul-up raw MAX_POW_RELATIVE_ERROR))))
+        )
+        (add-fixed raw max-error)
+    )
+)

--- a/clarity/contracts/new-lib/math-new-log-exp.clar
+++ b/clarity/contracts/new-lib/math-new-log-exp.clar
@@ -15,34 +15,34 @@
 (define-constant ONE_10 (pow 10 10))
 
 ;; The domain of natural exponentiation is bound by the word size and number of decimals used.
-;; The largest possible result is (2^127 - 1) / 10^8, 
-;; which makes the largest exponent ln((2^127 - 1) / 10^8) = 69.6090111872.
-;; The smallest possible result is 10^(-8), which makes largest negative argument ln(10^(-8)) = -18.420680744.
+;; The largest possible result is (2^127 - 1) / 10^10, 
+;; which makes the largest exponent ln((2^127 - 1) / 10^12) = 65.003841001.
+;; The smallest possible result is 10^(-12), which makes largest negative argument ln(10^(-12)) = -23.025850929.
 ;; We use 69.0 and -18.0 to have some safety margin.
-(define-constant MAX_NATURAL_EXPONENT (* 69 ONE_8))
-(define-constant MIN_NATURAL_EXPONENT (* -18 ONE_8))
+(define-constant MAX_NATURAL_EXPONENT (* 65 ONE_10))
+(define-constant MIN_NATURAL_EXPONENT (* -23 ONE_10))
 
-(define-constant MILD_EXPONENT_BOUND (/ (pow u2 u126) (to-uint ONE_8)))
+(define-constant MILD_EXPONENT_BOUND (/ (pow u2 u126) (to-uint ONE_10)))
 
-;; Because largest exponent is 69, we start from 64
+;; Because largest exponent is 65, we start from 64
 ;; The first several a_n are too large if stored as 8 decimal numbers, and could cause intermediate overflows.
 ;; Instead we store them as plain integers, with 0 decimals.
 (define-constant x_a_list_no_deci (list 
-{x_pre: 6400000000, a_pre: 6235149080811616882910000000, use_deci: false} ;; x1 = 2^6, a1 = e^(x1)
+{x_pre: 640000000000, a_pre: 6235149080811616882909238708, use_deci: false} ;; x1 = 2^6, a1 = e^(x1)
 ))
 ;; 8 decimal constants
 (define-constant x_a_list (list 
-{x_pre: 3200000000, a_pre: 7896296018268069516100, use_deci: true} ;; x2 = 2^5, a2 = e^(x2)
-{x_pre: 1600000000, a_pre: 888611052050787, use_deci: true} ;; x3 = 2^4, a3 = e^(x3)
-{x_pre: 800000000, a_pre: 298095798704, use_deci: true} ;; x4 = 2^3, a4 = e^(x4)
-{x_pre: 400000000, a_pre: 5459815003, use_deci: true} ;; x5 = 2^2, a5 = e^(x5)
-{x_pre: 200000000, a_pre: 738905610, use_deci: true} ;; x6 = 2^1, a6 = e^(x6)
-{x_pre: 100000000, a_pre: 271828183, use_deci: true} ;; x7 = 2^0, a7 = e^(x7)
-{x_pre: 50000000, a_pre: 164872127, use_deci: true} ;; x8 = 2^-1, a8 = e^(x8)
-{x_pre: 25000000, a_pre: 128402542, use_deci: true} ;; x9 = 2^-2, a9 = e^(x9)
-{x_pre: 12500000, a_pre: 113314845, use_deci: true} ;; x10 = 2^-3, a10 = e^(x10)
-{x_pre: 6250000, a_pre: 106449446, use_deci: true} ;; x11 = 2^-4, a11 = e^x(11)
-;;{x_pre: 3125000, a_pre: 103174341, use_deci: true} ;; x11 = 2^-4, a11 = e^x(11)
+{x_pre: 320000000000, a_pre: 7896296018268069516097, use_deci: true} ;; x2 = 2^5, a2 = e^(x2)
+{x_pre: 160000000000, a_pre: 888611052050787, use_deci: true} ;; x3 = 2^4, a3 = e^(x3)
+{x_pre: 80000000000, a_pre: 298095798704, use_deci: true} ;; x4 = 2^3, a4 = e^(x4)
+{x_pre: 40000000000, a_pre: 545981500331, use_deci: true} ;; x5 = 2^2, a5 = e^(x5)
+{x_pre: 20000000000, a_pre: 738905609893, use_deci: true} ;; x6 = 2^1, a6 = e^(x6)
+{x_pre: 10000000000, a_pre: 27182818284, use_deci: true} ;; x7 = 2^0, a7 = e^(x7)
+{x_pre: 5000000000, a_pre: 164872127070, use_deci: true} ;; x8 = 2^-1, a8 = e^(x8)
+{x_pre: 2500000000, a_pre: 128402541668, use_deci: true} ;; x9 = 2^-2, a9 = e^(x9)
+{x_pre: 1250000000, a_pre: 113314845307, use_deci: true} ;; x10 = 2^-3, a10 = e^(x10)
+{x_pre: 625000000, a_pre: 106449445892, use_deci: true} ;; x11 = 2^-4, a11 = e^x(11)
+{x_pre: 3125000, a_pre: 103174340750, use_deci: true} ;; x11 = 2^-4, a11 = e^x(11)
 ))
 
 (define-constant ERR-X-OUT-OF-BOUNDS (err u5009))
@@ -54,17 +54,17 @@
 ;; private functions
 ;;
 
-;; Internal natural logarithm (ln(a)) with signed 8 decimal fixed point argument.
-(define-read-only (ln-priv (a int))
+;; Internal natural logarithm (ln(a)) with signed 10 decimal fixed point argument.
+(define-private (ln-priv (a int))
   (let
     (
       (a_sum_no_deci (fold accumulate_division x_a_list_no_deci {a: a, sum: 0}))
       (a_sum (fold accumulate_division x_a_list {a: (get a a_sum_no_deci), sum: (get sum a_sum_no_deci)}))
       (out_a (get a a_sum))
       (out_sum (get sum a_sum))
-      (z (/ (* (- out_a ONE_8) ONE_8) (+ out_a ONE_8)))
-      (z_squared (/ (* z z) ONE_8))
-      (div_list (list 3 5 7 9 11))
+      (z (/ (* (- out_a ONE_10) ONE_10) (+ out_a ONE_10)))
+      (z_squared (/ (* z z) ONE_10))
+      (div_list (list 3 5 7 9 11 13))
       (num_sum_zsq (fold rolling_sum_div div_list {num: z, seriesSum: z, z_squared: z_squared}))
       (seriesSum (get seriesSum num_sum_zsq))
       (r (+ out_sum (* seriesSum 2)))
@@ -82,8 +82,8 @@
       (rolling_a (get a rolling_a_sum))
       (rolling_sum (get sum rolling_a_sum))
    )
-    (if (>= rolling_a (if use_deci a_pre (* a_pre ONE_8)))
-      {a: (/ (* rolling_a (if use_deci ONE_8 1)) a_pre), sum: (+ rolling_sum x_pre)}
+    (if (>= rolling_a (if use_deci a_pre (* a_pre ONE_10)))
+      {a: (/ (* rolling_a (if use_deci ONE_10 1)) a_pre), sum: (+ rolling_sum x_pre)}
       {a: rolling_a, sum: rolling_sum}
    )
  )
@@ -95,7 +95,7 @@
       (rolling_num (get num rolling))
       (rolling_sum (get seriesSum rolling))
       (z_squared (get z_squared rolling))
-      (next_num (/ (* rolling_num z_squared) ONE_8))
+      (next_num (/ (* rolling_num z_squared) ONE_10))
       (next_sum (+ rolling_sum (/ next_num n)))
    )
     {num: next_num, seriesSum: next_sum, z_squared: z_squared}
@@ -106,13 +106,13 @@
 ;; arrive at that result. In particular, exp(ln(x)) = x, and ln(x^y) = y * ln(x). This means
 ;; x^y = exp(y * ln(x)).
 ;; Reverts if ln(x) * y is smaller than `MIN_NATURAL_EXPONENT`, or larger than `MAX_NATURAL_EXPONENT`.
-(define-private (pow-priv (x uint) (y uint))
+(define-read-only (pow-priv (x uint) (y uint))
   (let
     (
       (x-int (to-int x))
       (y-int (to-int y))
       (lnx (unwrap-panic (ln-priv x-int)))
-      (logx-times-y (/ (* lnx y-int) ONE_8))
+      (logx-times-y (/ (* lnx y-int) ONE_10))
     )
     (asserts! (and (<= MIN_NATURAL_EXPONENT logx-times-y) (<= logx-times-y MAX_NATURAL_EXPONENT)) ERR-PRODUCT-OUT-OF-BOUNDS)
     (ok (to-uint (unwrap-panic (exp-fixed logx-times-y))))
@@ -129,15 +129,15 @@
         (x_product_no_deci (fold accumulate_product x_a_list_no_deci {x: x, product: 1}))
         (x_adj (get x x_product_no_deci))
         (firstAN (get product x_product_no_deci))
-        (x_product (fold accumulate_product x_a_list {x: x_adj, product: ONE_8}))
+        (x_product (fold accumulate_product x_a_list {x: x_adj, product: ONE_10}))
         (product_out (get product x_product))
         (x_out (get x x_product))
-        (seriesSum (+ ONE_8 x_out))
-        (div_list (list 2 3 4 5 6 7 8 9 10 11 12))
+        (seriesSum (+ ONE_10 x_out))
+        (div_list (list 2 3 4 5 6 7 8 9 10 11 12 13))
         (term_sum_x (fold rolling_div_sum div_list {term: x_out, seriesSum: seriesSum, x: x_out}))
         (sum (get seriesSum term_sum_x))
      )
-      (ok (* (/ (* product_out sum) ONE_8) firstAN))
+      (ok (* (/ (* product_out sum) ONE_10) firstAN))
    )
  )
 )
@@ -152,7 +152,7 @@
       (rolling_product (get product rolling_x_p))
    )
     (if (>= rolling_x x_pre)
-      {x: (- rolling_x x_pre), product: (/ (* rolling_product a_pre) (if use_deci ONE_8 1))}
+      {x: (- rolling_x x_pre), product: (/ (* rolling_product a_pre) (if use_deci ONE_10 1))}
       {x: rolling_x, product: rolling_product}
    )
  )
@@ -164,7 +164,7 @@
       (rolling_term (get term rolling))
       (rolling_sum (get seriesSum rolling))
       (x (get x rolling))
-      (next_term (/ (/ (* rolling_term x) ONE_8) n))
+      (next_term (/ (/ (* rolling_term x) ONE_10) n))
       (next_sum (+ rolling_sum next_term))
    )
     {term: next_term, seriesSum: next_sum, x: x}
@@ -178,7 +178,7 @@
   (ok MILD_EXPONENT_BOUND)
 )
 
-;; Exponentiation (x^y) with unsigned 8 decimal fixed point base and exponent.
+;; Exponentiation (x^y) with unsigned 10 decimal fixed point base and exponent.
 (define-read-only (pow-fixed (x uint) (y uint))
   (begin
     ;; The ln function takes a signed value, so we need to make sure x fits in the signed 128 bit range.
@@ -188,7 +188,7 @@
     (asserts! (< y MILD_EXPONENT_BOUND) ERR-Y-OUT-OF-BOUNDS)
 
     (if (is-eq y u0) 
-      (ok (to-uint ONE_8))
+      (ok (to-uint ONE_10))
       (if (is-eq x u0) 
         (ok u0)
         (pow-priv x y)
@@ -205,8 +205,8 @@
     (if (< x 0)
       ;; We only handle positive exponents: e^(-x) is computed as 1 / e^x. We can safely make x positive since it
       ;; fits in the signed 128 bit range (as it is larger than MIN_NATURAL_EXPONENT).
-      ;; Fixed point division requires multiplying by ONE_8.
-      (ok (/ (* ONE_8 ONE_8) (unwrap-panic (exp-pos (* -1 x)))))
+      ;; Fixed point division requires multiplying by ONE_10.
+      (ok (/ (* ONE_10 ONE_10) (unwrap-panic (exp-pos (* -1 x)))))
       (exp-pos x)
     )
   )
@@ -217,10 +217,10 @@
   ;; This performs a simple base change: log(arg, base) = ln(arg) / ln(base).
   (let
     (
-      (logBase (* (unwrap-panic (ln-priv base)) ONE_8))
-      (logArg (* (unwrap-panic (ln-priv arg)) ONE_8))
+      (logBase (* (unwrap-panic (ln-priv base)) ONE_10))
+      (logArg (* (unwrap-panic (ln-priv arg)) ONE_10))
    )
-    (ok (/ (* logArg ONE_8) logBase))
+    (ok (/ (* logArg ONE_10) logBase))
  )
 )
 
@@ -228,11 +228,11 @@
 (define-read-only (ln-fixed (a int))
   (begin
     (asserts! (> a 0) (err ERR-OUT-OF-BOUNDS))
-    (if (< a ONE_8)
+    (if (< a ONE_10)
       ;; Since ln(a^k) = k * ln(a), we can compute ln(a) as ln(a) = ln((1/a)^(-1)) = - ln((1/a)).
       ;; If a is less than one, 1/a will be greater than one.
-      ;; Fixed point division requires multiplying by ONE_8.
-      (ok (- 0 (unwrap-panic (ln-priv (/ (* ONE_8 ONE_8) a)))))
+      ;; Fixed point division requires multiplying by ONE_10.
+      (ok (- 0 (unwrap-panic (ln-priv (/ (* ONE_10 ONE_10) a)))))
       (ln-priv a)
    )
  )
@@ -246,12 +246,12 @@
       (x-int (to-int x))
       (y-int (to-int y))
       (lnx (unwrap-panic (ln-priv x-int)))
-      (logx-times-y (/ (* lnx y-int) ONE_8))
+      (logx-times-y (/ (* lnx y-int) ONE_10))
       ;;(r (exp-pos (* -1 logx-times-y)))
 
-      ;;(arg (* 69 ONE_8))
+      ;;(arg (* 69 ONE_10))
       ;;(r (exp-pos arg))
-      ;;(x_product (fold accumulate_product x_a_list {x: arg, product: ONE_8}))
+      ;;(x_product (fold accumulate_product x_a_list {x: arg, product: ONE_10}))
   )
   ;;(ok logx-times-y)
   ;;x_product

--- a/clarity/tests/collateral-rebalancing-pool_test.ts
+++ b/clarity/tests/collateral-rebalancing-pool_test.ts
@@ -409,16 +409,16 @@ Clarinet.test({
         
         // let's do some arb
         call = await FWPTest.getYgivenPrice(wbtcAddress, usdaAddress, weightX, weightY, wbtcPrice * 1.5);
-        call.result.expectOk().expectUint(90683373999371);         
-        result = FWPTest.swapYForX(deployer, wbtcAddress, usdaAddress, weightX, weightY, 90683373999371)
+        call.result.expectOk().expectUint(90683373999370);         
+        result = FWPTest.swapYForX(deployer, wbtcAddress, usdaAddress, weightX, weightY, 90683373999370)
         position = result.expectOk().expectTuple();
-        position['dy'].expectUint(90683373999371);
+        position['dy'].expectUint(90683373999370);
         position['dx'].expectUint(2199052387);
 
         call = await FWPTest.getPoolDetails(wbtcAddress, usdaAddress, weightX, weightY);
         position = call.result.expectOk().expectTuple();
         position['balance-x'].expectUint(7767370713);
-        position['balance-y'].expectUint(592356647699371);         
+        position['balance-y'].expectUint(592356647699370);         
         
         // simulate to expiry + 1
         chain.mineEmptyBlockUntil((expiry / ONE_8) + 1) 
@@ -577,11 +577,11 @@ Clarinet.test({
         
         // arbtrageur sells wbtc for $ at ~$65,000 per wbtc (vs. $44,000 printed), making tidy profits
         call = await CRPTest.getYgivenPrice(wbtcAddress, usdaAddress, expiry, Math.round( ONE_8 / (wbtcPrice * 1.1 * 0.8 / ONE_8)));
-        call.result.expectOk().expectUint(22562287);
-        result = CRPTest.swapYForX(deployer, wbtcAddress, usdaAddress, expiry, 22562287);
+        call.result.expectOk().expectUint(22562286);
+        result = CRPTest.swapYForX(deployer, wbtcAddress, usdaAddress, expiry, 22562286);
         position = result.expectOk().expectTuple();
-        position['dx'].expectUint(2368068346005);
-        position['dy'].expectUint(22562287);     
+        position['dx'].expectUint(2368068036575);
+        position['dy'].expectUint(22562286);     
         // the rebalance, based on the original weigting brings back implied price to ~$44,000
         // 1070037083192 * 70690442 / 54011214 / 29309558 = 47782.219378044761895
 
@@ -589,8 +589,8 @@ Clarinet.test({
         position = call.result.expectOk().expectTuple();
         position['weight-x'].expectUint(71490515);
         position['weight-y'].expectUint(28509485);        
-        position['balance-x'].expectUint(3438105429197 - 2368068346005);
-        position['balance-y'].expectUint(31448927 + 22562287);       
+        position['balance-x'].expectUint(3438105429197 - 2368068036575);
+        position['balance-y'].expectUint(31448927 + 22562286);       
     },    
 });        
 

--- a/clarity/tests/models/alex-tests-tokens.ts
+++ b/clarity/tests/models/alex-tests-tokens.ts
@@ -28,7 +28,7 @@ class USDAToken {
             types.uint(amount),
             types.principal(sender),
             types.principal(receiver),
-            types.buff(memo)
+            types.some(types.buff(memo))
           ], this.deployer.address),
         ]);
         return block.receipts[0].result;
@@ -63,7 +63,7 @@ class USDAToken {
             types.uint(amount),
             types.principal(sender),
             types.principal(receiver),
-            types.buff(memo)
+            types.some(types.buff(memo))
           ], this.deployer.address),
         ]);
         return block.receipts[0].result;

--- a/clarity/tests/yield-token-pool_test.ts
+++ b/clarity/tests/yield-token-pool_test.ts
@@ -265,9 +265,9 @@ Clarinet.test({
         const feeRateX = 5000000; // 5%
         const feeRateY = 5000000;
 
-        // let money = usdaToken.transferToken(10*ONE_8,deployer.address,wallet_1.address, buffer);
-        // money = wbtcToken.transferToken(10*ONE_8,deployer.address,wallet_1.address, buffer);
-        // money.expectOk()
+        let money = usdaToken.transferToken(10*ONE_8,deployer.address,wallet_2.address, buffer);
+        money = wbtcToken.transferToken(10*ONE_8,deployer.address,wallet_2.address, buffer);
+        money.expectOk()
 
         //Deployer creating a pool, initial tokens injected to the pool
         let result = YTPTest.createPool(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, multisigytpyieldwbtc59760, 1000*ONE_8, 1000*ONE_8);
@@ -279,24 +279,30 @@ Clarinet.test({
         position['balance-token'].expectUint(1000*ONE_8);
         position['balance-aytoken'].expectUint(0);
         position['balance-virtual'].expectUint(1000*ONE_8);
-        
+
+        result = YTPTest.addToPosition(wallet_2, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 10*ONE_8);
+        position = result.expectOk().expectTuple();
+        position['supply'].expectUint(10*ONE_8);
+        position['balance-token'].expectUint(10*ONE_8);
+        position['balance-aytoken'].expectUint(0);
+        position['balance-virtual'].expectUint(10*ONE_8);   
+
         result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, ONE_8);
         position =result.expectOk().expectTuple();
-        position['dx'].expectUint(99954689);
+        position['dx'].expectUint(99951128); //99954689
         position['dy'].expectUint(ONE_8);
 
         call = await YTPTest.getPoolDetails(yieldwbtc59760Address);
         position = call.result.expectOk().expectTuple();
-        position['balance-token'].expectUint(99900045311);
+        position['balance-token'].expectUint(100900048872); // u99900045311
         position['balance-aytoken'].expectUint(ONE_8);
-        position['balance-virtual'].expectUint(1000*ONE_8);
-
+        position['balance-virtual'].expectUint(1010*ONE_8);
 
         call = await ytpPoolToken.balanceOf(deployer.address);
-        call.result.expectOk().expectUint(100000000000);
+        call.result.expectOk().expectUint(100000000000);    // u100000000000
 
         call = await ytpPoolToken.balanceOf(wallet_2.address);
-        call.result.expectOk().expectUint(0);
+        call.result.expectOk().expectUint(1000000000);
 
         // Fee rate Setting Proposal of Multisig
         result = MultiSigTest.propose(1000, " Fee Rate Setting to 5%", " https://docs.alexgo.io", feeRateX, feeRateY)
@@ -305,10 +311,14 @@ Clarinet.test({
         // Block 1000 mining
         chain.mineEmptyBlock(1000);
 
-        // Deployer has 100 % of pool token
+        // Deployer has 99 % of pool token
         let ROresult:any = ytpPoolToken.balanceOf(deployer.address);
         ROresult.result.expectOk().expectUint(100000000000);
-                
+        
+        // Wallet_2 votes his 90% asset
+        result = MultiSigTest.voteFor(wallet_2, ytpyieldwbtc59760Address, 1, 1000000000 * 9 / 10 )
+        result.expectOk().expectUint(900000000)
+
         // 90 % of existing tokens are voted for the proposal
         result = MultiSigTest.voteFor(deployer, ytpyieldwbtc59760Address, 1, 100000000000 * 9 / 10 )
         result.expectOk().expectUint(90000000000)
@@ -320,5 +330,111 @@ Clarinet.test({
         result.expectOk().expectBool(true) // Success 
 
         
+    },    
+});
+
+Clarinet.test({
+    name: "YTP : Error Test Cases ",
+
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let deployer = accounts.get("wallet_1")!;
+        let wallet_2 = accounts.get("wallet_2")!;
+        let YTPTest = new YTPTestAgent1(chain, deployer);
+        let MultiSigTest = new MS_YTP_WBT_59760(chain, deployer);
+        let ytpPoolToken = new POOLTOKEN_YTP_WBTC_WBTC_59760(chain, deployer);
+        let usdaToken = new USDAToken(chain, deployer);
+        let wbtcToken = new WBTCToken(chain, deployer);
+        const buffer = new ArrayBuffer(0)   // Optional memo
+
+        let money = usdaToken.transferToken(10*ONE_8,deployer.address,wallet_2.address, buffer);
+        money = wbtcToken.transferToken(10*ONE_8,deployer.address,wallet_2.address, buffer);
+        money.expectOk()
+
+        //Deployer creating a pool, initial tokens injected to the pool
+        let result = YTPTest.createPool(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, multisigytpyieldwbtc59760, 1000*ONE_8, 1000*ONE_8);
+        result.expectOk().expectBool(true);
+
+        // Duplicated Pool 
+        result = YTPTest.createPool(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, multisigytpyieldwbtc59760, 1000*ONE_8, 1000*ONE_8);
+        result.expectErr().expectUint(2000);
+
+        // Check pool details and print
+        let call = await YTPTest.getPoolDetails(yieldwbtc59760Address);
+        let position:any = call.result.expectOk().expectTuple();
+        position['balance-token'].expectUint(1000*ONE_8);
+        position['balance-aytoken'].expectUint(0);
+        position['balance-virtual'].expectUint(1000*ONE_8);
+        
+        // Attempts to inject zero liquidity
+        result = YTPTest.addToPosition(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 0);
+        position = result.expectErr().expectUint(2003)
+
+        //Attempt to add extra liquidity but not enough balance
+        result = YTPTest.addToPosition(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 1000000*ONE_8);
+        position = result.expectErr().expectUint(3001)
+
+        // Attempts for trivial reducing
+        result = YTPTest.reducePosition(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 0);
+        position =result.expectErr().expectUint(1)
+
+        // Attempts for trivial reduce more than 100%
+        result = YTPTest.reducePosition(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 101*ONE_8);
+        position =result.expectErr().expectUint(5000)
+
+        // Another user attempts to reduce liquidity with not enough pool token 
+        result = YTPTest.reducePosition(wallet_2, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 1*ONE_8);
+        position =result.expectErr().expectUint(1)
+
+        // Deployer adds liquidity
+        result = YTPTest.addToPosition(deployer, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 1000*ONE_8);
+        position = result.expectOk().expectTuple();
+        position['supply'].expectUint(1000*ONE_8);
+        position['balance-token'].expectUint(1000*ONE_8);
+        position['balance-aytoken'].expectUint(0);
+        position['balance-virtual'].expectUint(1000*ONE_8);     
+
+        // Another User adds liquidity
+        result = YTPTest.addToPosition(wallet_2, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 10*ONE_8);
+        position = result.expectOk().expectTuple();
+        position['supply'].expectUint(10*ONE_8);
+        position['balance-token'].expectUint(10*ONE_8);
+        position['balance-aytoken'].expectUint(0);
+        position['balance-virtual'].expectUint(10*ONE_8);     
+
+        // Another user attempts to reduce liquidity with zero value
+        result = YTPTest.reducePosition(wallet_2, yieldwbtc59760Address, wbtcAddress, ytpyieldwbtc59760Address, 0);
+        position =result.expectErr().expectUint(1)
+
+        // False swap value -- Filter added
+        result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, 0);
+        position =result.expectErr().expectUint(2003)
+        
+        // call = await YTPTest.getPoolDetails(yieldwbtc59760Address);
+        // position = call.result.expectErr();
+
+        // Bug, this should pass -- to be checked
+        result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, 0.001 * ONE_8);
+        position =result.expectErr().expectUint(5004)
+
+        // Attempt for Swapping
+        result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, ONE_8);
+        position =result.expectOk().expectTuple();
+        position['dx'].expectUint(99787067);
+        position['dy'].expectUint(ONE_8);
+
+        // Attempts for zero value swapping
+        result = YTPTest.swapXForY(deployer, yieldwbtc59760Address, wbtcAddress, 0);
+        position =result.expectErr().expectUint(2003)
+
+        // Attempts to swap more than available balance in the pool
+        result = YTPTest.swapXForY(deployer, yieldwbtc59760Address, wbtcAddress, 100*ONE_8);
+        position =result.expectErr().expectUint(2016) 
+
+        // Swap
+        result = YTPTest.swapXForY(deployer, yieldwbtc59760Address, wbtcAddress, 0.1 * ONE_8);
+        position =result.expectOk().expectTuple();
+        position['dx'].expectUint(0.1 * ONE_8);
+        position['dy'].expectUint(10161454);
+
     },    
 });

--- a/clarity/tests/yield-token-pool_test.ts
+++ b/clarity/tests/yield-token-pool_test.ts
@@ -409,17 +409,25 @@ Clarinet.test({
         result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, 0);
         position =result.expectErr().expectUint(2003)
         
+        // False swap value -- Filter added
+        result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, 0.0000001 * ONE_8);
+        //position =result.expectErr().expectUint(2003)
+        position =result.expectOk().expectTuple();
+        position['dx'].expectUint(0);
+        position['dy'].expectUint(0.0000001 * ONE_8);
         // call = await YTPTest.getPoolDetails(yieldwbtc59760Address);
         // position = call.result.expectErr();
 
-        // Bug, this should pass -- to be checked
+        // Fixed
         result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, 0.001 * ONE_8);
-        position =result.expectErr().expectUint(5004)
+        position =result.expectOk().expectTuple();
+        position['dx'].expectUint(0);
+        position['dy'].expectUint(0.001 * ONE_8);
 
         // Attempt for Swapping
         result = YTPTest.swapYForX(deployer, yieldwbtc59760Address, wbtcAddress, ONE_8);
         position =result.expectOk().expectTuple();
-        position['dx'].expectUint(99787067);
+        position['dx'].expectUint(99760122);
         position['dy'].expectUint(ONE_8);
 
         // Attempts for zero value swapping
@@ -434,7 +442,7 @@ Clarinet.test({
         result = YTPTest.swapXForY(deployer, yieldwbtc59760Address, wbtcAddress, 0.1 * ONE_8);
         position =result.expectOk().expectTuple();
         position['dx'].expectUint(0.1 * ONE_8);
-        position['dy'].expectUint(10161454);
+        position['dy'].expectUint(10178704);
 
     },    
 });


### PR DESCRIPTION
the value of usd shall be at least 1 usd. 
floating point shall be at least 0.0000001 * ONE_8 , floating point error occurs. 

One good thing is that whenever we get unwrap panic error, it seems to be related to floating point math library error. For others, we were mostly able to catch up with specific error code  . 


For the below error, I think investigation is required. Shouldn't this pass? 

The error throwing contract call is this :
(contract-call? 'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.yield-token-equation get-x-given-y u1000000000000 u1000000000000 u85000000 u1000000)

where pw-down term is u398107168 and exponential is u666666666 ,  which throws an error because the result is smaller than balance u1000000000000

