### PR TITLE
Dynamic oracle src/158

### DIFF
--- a/clarity/contracts/pool/alex-reserve-pool.clar
+++ b/clarity/contracts/pool/alex-reserve-pool.clar
@@ -28,7 +28,8 @@
 
 (define-constant ONE_8 (pow u10 u8)) ;; 8 decimal places
 
-(define-constant oracle-src "nothing")
+
+(define-data-var oracle-src (string-ascii 32) "coingecko")
 
 (define-data-var contract-owner principal tx-sender)
 
@@ -42,6 +43,17 @@
 
 (define-read-only (get-owner)
   (ok (var-get contract-owner))
+)
+
+(define-read-only (get-oracle-src)
+  (ok (var-get oracle-src))
+)
+
+(define-public (set-oracle-src (new-oracle-src (string-ascii 32)))
+  (begin
+    (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
+    (ok (var-set oracle-src new-oracle-src))
+  )
 )
 
 (define-public (set-owner (owner principal))
@@ -71,16 +83,17 @@
   (begin
     (asserts! (> usda-amount u0) ERR-INVALID-LIQUIDITY)
     (let
-        (
+        (   
             (amount-to-rebate (unwrap! (mul-down usda-amount (var-get rebate-rate)) ERR-MATH-CALL))
             (usda-symbol (unwrap! (contract-call? .token-usda get-symbol) ERR-GET-SYMBOL-FAIL))
             (alex-symbol (unwrap! (contract-call? .token-alex get-symbol) ERR-GET-SYMBOL-FAIL))
-            (usda-price (unwrap! (contract-call? .open-oracle get-price oracle-src usda-symbol) ERR-GET-ORACLE-PRICE-FAIL))
-            (alex-price (unwrap! (contract-call? .open-oracle get-price oracle-src alex-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+            (usda-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) usda-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+            (alex-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) alex-symbol) ERR-GET-ORACLE-PRICE-FAIL))
             (usda-to-alex (unwrap! (div-down usda-price alex-price) ERR-MATH-CALL))
             (alex-to-rebate (unwrap! (mul-down amount-to-rebate usda-to-alex) ERR-MATH-CALL))
         )
         ;; all usdc amount is transferred
+        ;; (print oracle)
         (try! (contract-call? .token-usda transfer usda-amount tx-sender (as-contract tx-sender) none))
         ;; portion of that (by rebate-rate) is minted as alex and transferred        
         (try! (contract-call? .token-alex mint tx-sender alex-to-rebate))

--- a/clarity/contracts/pool/collateral-rebalancing-pool.clar
+++ b/clarity/contracts/pool/collateral-rebalancing-pool.clar
@@ -40,8 +40,8 @@
 (define-constant a4 u7810800)
 
 ;; TODO: need to be defined properly
-(define-constant oracle-src "nothing")
-
+(define-data-var contract-owner principal tx-sender)
+(define-data-var oracle-src (string-ascii 32) "coingecko")
 ;; data maps and vars
 ;;
 (define-map pools-map
@@ -116,6 +116,17 @@
 ;; public functions
 ;;
 
+(define-read-only (get-oracle-src)
+  (ok (var-get oracle-src))
+)
+
+(define-public (set-oracle-src (new-oracle-src (string-ascii 32)))
+  (begin
+    (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
+    (ok (var-set oracle-src new-oracle-src))
+  )
+)
+
 ;; implement trait-pool
 (define-read-only (get-pool-count)
     (ok (var-get pool-count))
@@ -149,8 +160,8 @@
             (pool (unwrap! (map-get? pools-data-map { token-x: token-x, token-y: token-y, expiry: expiry }) ERR-INVALID-POOL-ERR))                        
             (token-symbol (get token-symbol pool))
             (collateral-symbol (get collateral-symbol pool))
-            (token-price (unwrap! (contract-call? .open-oracle get-price oracle-src token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
-            (collateral-price (unwrap! (contract-call? .open-oracle get-price oracle-src collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))            
+            (token-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+            (collateral-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))            
         )
         (ok (unwrap-panic (div-down token-price collateral-price)))
     )
@@ -167,8 +178,8 @@
             (balance-y (get balance-y pool))   
             (token-symbol (get token-symbol pool))
             (collateral-symbol (get collateral-symbol pool))
-            (token-price (unwrap! (contract-call? .open-oracle get-price oracle-src token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
-            (collateral-price (unwrap! (contract-call? .open-oracle get-price oracle-src collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))  
+            (token-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+            (collateral-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))  
             (token-value (unwrap! (mul-down balance-x collateral-price) ERR-MATH-CALL))
             (balance-x-in-y (unwrap! (div-down token-value token-price) ERR-MATH-CALL))
         )
@@ -186,8 +197,8 @@
             (balance-y (get balance-y pool))   
             (token-symbol (get token-symbol pool))
             (collateral-symbol (get collateral-symbol pool))
-            (token-price (unwrap! (contract-call? .open-oracle get-price oracle-src token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
-            (collateral-price (unwrap! (contract-call? .open-oracle get-price oracle-src collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))  
+            (token-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+            (collateral-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))  
             (collateral-value (unwrap! (mul-down balance-y token-price) ERR-MATH-CALL))
             (balance-y-in-x (unwrap! (div-down collateral-value collateral-price) ERR-MATH-CALL))
         )
@@ -296,8 +307,8 @@
 
                 (token-symbol (try! (contract-call? token get-symbol)))
                 (collateral-symbol (try! (contract-call? collateral get-symbol)))
-                (token-price (unwrap! (contract-call? .open-oracle get-price oracle-src token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
-                (collateral-price (unwrap! (contract-call? .open-oracle get-price oracle-src collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+                (token-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+                (collateral-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) collateral-symbol) ERR-GET-ORACLE-PRICE-FAIL))
             
                 (strike (unwrap-panic (div-down token-price collateral-price)))
 

--- a/clarity/contracts/pool/fixed-weight-pool.clar
+++ b/clarity/contracts/pool/fixed-weight-pool.clar
@@ -28,7 +28,8 @@
 
 (define-constant alex-symbol "alex")
 (define-constant reserve-usdc-symbol "usdc")
-(define-constant oracle-src "nothing")
+(define-data-var contract-owner principal tx-sender)
+(define-data-var oracle-src (string-ascii 32) "coingecko")
 
 ;; data maps and vars
 (define-map pools-map
@@ -106,6 +107,17 @@
       (pool (unwrap! (map-get? pools-data-map { token-x: token-x, token-y: token-y, weight-x: weight-x, weight-y: weight-y  }) ERR-INVALID-POOL-ERR))
     )
     (ok {balance-x: (get balance-x pool), balance-y: (get balance-y pool)})
+  )
+)
+
+(define-read-only (get-oracle-src)
+  (ok (var-get oracle-src))
+)
+
+(define-public (set-oracle-src (new-oracle-src (string-ascii 32)))
+  (begin
+    (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
+    (ok (var-set oracle-src new-oracle-src))
   )
 )
 

--- a/clarity/contracts/pool/yield-token-pool.clar
+++ b/clarity/contracts/pool/yield-token-pool.clar
@@ -31,7 +31,8 @@
 (define-constant ERR-GET-SYMBOL-FAIL (err u6000))
 
 ;; TODO: need to be defined properly
-(define-constant oracle-src "nothing")
+(define-data-var contract-owner principal tx-sender)
+(define-data-var oracle-src (string-ascii 32) "coingecko")
 
 ;; data maps and vars
 (define-map pools-map
@@ -69,6 +70,17 @@
 
 (define-read-only (get-max-expiry)
     (ok (var-get max-expiry))
+)
+
+(define-read-only (get-oracle-src)
+  (ok (var-get oracle-src))
+)
+
+(define-public (set-oracle-src (new-oracle-src (string-ascii 32)))
+  (begin
+    (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
+    (ok (var-set oracle-src new-oracle-src))
+  )
 )
 
 (define-read-only (get-t (expiry uint) (listed uint))
@@ -117,7 +129,7 @@
             (balance-token (get balance-token pool))
             (balance-aytoken (get balance-aytoken pool))
             (token-symbol (get token-symbol pool))         
-            (token-price (unwrap! (contract-call? .open-oracle get-price oracle-src token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
+            (token-price (unwrap! (contract-call? .open-oracle get-price (var-get oracle-src) token-symbol) ERR-GET-ORACLE-PRICE-FAIL))
             (balance (unwrap! (add-fixed balance-token balance-aytoken) ERR-MATH-CALL))
         )
         (mul-up balance token-price)

--- a/clarity/tests/collateral-rebalancing-pool_test.ts
+++ b/clarity/tests/collateral-rebalancing-pool_test.ts
@@ -58,9 +58,9 @@ Clarinet.test({
         let YTPTest = new YTPTestAgent1(chain, deployer);
         let Oracle = new OracleManager(chain, deployer);
         
-        let oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice);
+        let oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice);
         oracleresult.expectOk()
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()
         
         let result = FWPTest.createPool(deployer, wbtcAddress, usdaAddress, weightX, weightY, fwpwbtcusdaAddress, multisigfwpAddress, wbtcQ, Math.round(wbtcPrice * wbtcQ / ONE_8));
@@ -139,7 +139,7 @@ Clarinet.test({
         call.result.expectOk().expectUint(33465993);          
 
         // wbtc (token) falls by 20% vs usda (collateral)
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing", Math.round(wbtcPrice * 0.8));
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko", Math.round(wbtcPrice * 0.8));
         oracleresult.expectOk()
 
         // move forward by one day
@@ -167,7 +167,7 @@ Clarinet.test({
         chain.mineEmptyBlockUntil((expiry / ONE_8) / 2)    
 
         // wbtc rises then by 50%
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice * 0.8 * 1.5);
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice * 0.8 * 1.5);
         oracleresult.expectOk();      
 
         // the rise shifts allocation to wbtc (token)
@@ -192,7 +192,7 @@ Clarinet.test({
         chain.mineEmptyBlockUntil((expiry / ONE_8) * 3 / 4)    
 
         // what if wbtc rises then by another 10%
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing", Math.round(wbtcPrice * 0.8 * 1.5 * 1.1));
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko", Math.round(wbtcPrice * 0.8 * 1.5 * 1.1));
         oracleresult.expectOk();
 
         // we hold over 60% in usda, so pool value in wbtc goes down
@@ -309,10 +309,10 @@ Clarinet.test({
         let YTPTest = new YTPTestAgent1(chain, deployer);
         let Oracle = new OracleManager(chain, deployer);
         
-        let oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice);
+        let oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice);
         oracleresult.expectOk()
 
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()
         
         let result = FWPTest.createPool(deployer, wbtcAddress, usdaAddress, weightX, weightY, fwpwbtcusdaAddress, multisigfwpAddress, wbtcQ, Math.round(wbtcPrice * wbtcQ / ONE_8));
@@ -334,7 +334,7 @@ Clarinet.test({
         chain.mineEmptyBlockUntil((expiry / ONE_8) / 2)    
 
         // wbtc rises then by 50%
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing", Math.round(wbtcPrice * 0.8 * 1.5));
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko", Math.round(wbtcPrice * 0.8 * 1.5));
         oracleresult.expectOk();
 
         result = YTPTest.createPool(deployer, yieldwbtc79760Address, wbtcAddress, ytpyieldwbtc79760Address, multisigytpyieldwbtc79760, wbtcQ / 10, wbtcQ / 10);        
@@ -355,10 +355,10 @@ Clarinet.test({
         let YTPTest = new YTPTestAgent1(chain, deployer);
         let Oracle = new OracleManager(chain, deployer);
         
-        let oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice);
+        let oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice);
         oracleresult.expectOk()
 
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()
         
         let result = FWPTest.createPool(deployer, wbtcAddress, usdaAddress, weightX, weightY, fwpwbtcusdaAddress, multisigfwpAddress, wbtcQ, Math.round(wbtcQ*wbtcPrice/ONE_8));
@@ -395,10 +395,10 @@ Clarinet.test({
         position['moving-average'].expectUint(moving_average);   
 
         // wbtc (token) rises by 50% vs usda (collateral)
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice * 1.5);
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice * 1.5);
         oracleresult.expectOk()    
         
-        call = await Oracle.getPrice("nothing", "WBTC");
+        call = await Oracle.getPrice("coingecko", "WBTC");
         call.result.expectOk().expectUint(wbtcPrice * 1.5);
 
         // now pool price still implies $50,000 per wbtc
@@ -501,9 +501,9 @@ Clarinet.test({
         let YTPTest = new YTPTestAgent1(chain, deployer);
         let Oracle = new OracleManager(chain, deployer);
         
-        let oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice);
+        let oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice);
         oracleresult.expectOk()
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()
         
         let result = FWPTest.createPool(deployer, wbtcAddress, usdaAddress, weightX, weightY, fwpwbtcusdaAddress, multisigfwpAddress, wbtcQ, Math.round(wbtcPrice * wbtcQ / ONE_8));
@@ -544,9 +544,9 @@ Clarinet.test({
         position['moving-average'].expectUint(moving_average);
 
         // WBTC rises by 10%
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice * 1.1);
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice * 1.1);
         oracleresult.expectOk()
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()
 
         // arbtrageur sells $ for wbtc at ~$52,000 per wbtc, making tidy profits
@@ -570,9 +570,9 @@ Clarinet.test({
         // this leads to impermanent loss, hence moving-average in this context is important.
 
         // WBTC falls by 20%
-        oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice * 1.1 * 0.8);
+        oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice * 1.1 * 0.8);
         oracleresult.expectOk()
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()  
         
         // arbtrageur sells wbtc for $ at ~$65,000 per wbtc (vs. $44,000 printed), making tidy profits

--- a/clarity/tests/fixed-weight-pool_test.ts
+++ b/clarity/tests/fixed-weight-pool_test.ts
@@ -292,9 +292,9 @@ Clarinet.test({
         let Oracle = new OracleManager(chain, deployer);
         
         // initialise prices
-        let oracleresult = Oracle.updatePrice(deployer,"WBTC", "nothing" ,wbtcPrice * ONE_8);
+        let oracleresult = Oracle.updatePrice(deployer,"WBTC", "coingecko" ,wbtcPrice * ONE_8);
         oracleresult.expectOk()            
-        oracleresult = Oracle.updatePrice(deployer,"USDA", "nothing" ,usdaPrice * ONE_8);
+        oracleresult = Oracle.updatePrice(deployer,"USDA", "coingecko" ,usdaPrice * ONE_8);
         oracleresult.expectOk()                    
 
         // Deployer creating a pool, initial tokens injected to the pool
@@ -309,7 +309,7 @@ Clarinet.test({
         position['balance-y'].expectUint(wbtcQ*wbtcPrice);
 
         // wbtc (token) rises by 10% vs usda (collateral)
-        oracleresult = Oracle.updatePrice(deployer,"WBTC", "nothing" ,wbtcPrice * ONE_8 * 1.1);
+        oracleresult = Oracle.updatePrice(deployer,"WBTC", "coingecko" ,wbtcPrice * ONE_8 * 1.1);
         oracleresult.expectOk()
 
         // now pool price still implies wbtcPrice
@@ -334,7 +334,7 @@ Clarinet.test({
         position['balance-y'].expectUint(500000000000000 + 23268715000000);     
 
         // wbtc (token) then falls by 30% vs usda (collateral)
-        oracleresult = Oracle.updatePrice(deployer,"WBTC", "nothing" ,wbtcPrice * ONE_8 * 1.1 * 0.8);
+        oracleresult = Oracle.updatePrice(deployer,"WBTC", "coingecko" ,wbtcPrice * ONE_8 * 1.1 * 0.8);
         oracleresult.expectOk()        
         
         // let's do some arb

--- a/clarity/tests/flash-loan_test.ts
+++ b/clarity/tests/flash-loan_test.ts
@@ -56,10 +56,10 @@ Clarinet.test({
         let Oracle = new OracleManager(chain, deployer);
         let FLTest = new FLTestAgent1(chain, deployer);
         
-        let oracleresult = Oracle.updatePrice(deployer,"WBTC","nothing",wbtcPrice);
+        let oracleresult = Oracle.updatePrice(deployer,"WBTC","coingecko",wbtcPrice);
         oracleresult.expectOk()
 
-        oracleresult = Oracle.updatePrice(deployer,"USDA","nothing",usdaPrice);
+        oracleresult = Oracle.updatePrice(deployer,"USDA","coingecko",usdaPrice);
         oracleresult.expectOk()
         
         let result = FWPTest.createPool(deployer, wbtcAddress, usdaAddress, weightX, weightY, fwpwbtcusdaAddress, multisigfwpAddress, wbtcQ, Math.round(wbtcPrice * wbtcQ / ONE_8));


### PR DESCRIPTION
I updated the oracle-src constant to a data-var with the default value as "coingecko" and allowed the contract owner to edit it. I had to add a contract owner parameter to the CRP.

Also, I updated the testing suite to reflect "coingecko" instead of "nothing."

Once we deploy these contracts, we must update the init-js scripts to use "coingecko."