### PR TITLE
Add vs-code tasks for clarinet check and test

### DIFF
--- a/clarity/.vscode/tasks.json
+++ b/clarity/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "check contract",
+      "group": "test",
+      "type": "shell",
+      "command": "clarinet check"
+    },
+    {
+      "label": "test contract",
+      "group": "test",
+      "type": "shell",
+      "command": "clarinet test"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces vs-code tasks that can run both `clarinet check` and `clarinet test`.