### PR TITLE
fixes #220

### DIFF
--- a/clarity/contracts/pool/yield-token-pool.clar
+++ b/clarity/contracts/pool/yield-token-pool.clar
@@ -268,6 +268,26 @@
     )
 )
 
+;; @desc buy-and-add-to-position
+;; @desc helper function to buy required yield-token before adding position
+;; @desc returns units of pool tokens minted, dx, dy-actual and dy-virtual added
+;; @param the-aytoken; yield token
+;; @param the-token; token
+;; @param pool-token; pool token representing ownership of the pool
+;; @param dx; amount of token added (part of which will be used to buy yield-token)
+;; @returns (response (tuple uint uint uint uint) uint)
+(define-public (buy-and-add-to-position (the-aytoken <yield-token-trait>) (the-token <ft-trait>) (the-pool-token <pool-token-trait>) (dx uint))
+    (let
+        (
+            (dy-act (get dy-act (try! (get-token-given-position the-aytoken dx))))
+            (dx-adjusted (- dx (div-down dx (+ dx (try! (get-x-given-y the-aytoken dy-act))))))
+            (dx-to-buy-dy-adjusted (- dx dx-adjusted))
+        )
+        (and (> dy-act u0) (is-ok (swap-x-for-y the-aytoken the-token dx-to-buy-dy-adjusted none)))
+        (add-to-position the-aytoken the-token the-pool-token dx-adjusted)
+    )
+)
+
 ;; @desc add-to-position
 ;; @desc returns units of pool tokens minted, dx, dy-actual and dy-virtual added
 ;; @param the-aytoken; yield token

--- a/clarity/tests/models/alex-tests-yield-token-pool.ts
+++ b/clarity/tests/models/alex-tests-yield-token-pool.ts
@@ -65,6 +65,18 @@ import {
         ]);
         return block.receipts[0].result;
       }
+
+      buyAndAddToPosition(user: Account, aytoken: string, token: string, pooltoken: string, dX: number) {
+        let block = this.chain.mineBlock([
+          Tx.contractCall("yield-token-pool", "buy-and-add-to-position", [
+            types.principal(aytoken),
+            types.principal(token),
+            types.principal(pooltoken),
+            types.uint(dX),
+          ], user.address),
+        ]);
+        return block.receipts[0].result;
+      }      
   
       reducePosition(user: Account, aytoken: string, token: string, pooltoken: string, percent: number) {
         let block = this.chain.mineBlock([


### PR DESCRIPTION
`yield-token-pool` single sided liquidity is done by swapping some of `token` to the required `yield-token` in the secondary (i.e. instead of freshly minting `yield-token` from `collateral-rebalancing-pool`).