### PR TITLE
chore: rename ownable trait functions

### DIFF
--- a/clarity/contracts/alex-vault.clar
+++ b/clarity/contracts/alex-vault.clar
@@ -21,11 +21,11 @@
 ;; flash loan fee rate
 (define-data-var flash-loan-fee-rate uint u0)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/equations/weighted-equation.clar
+++ b/clarity/contracts/equations/weighted-equation.clar
@@ -57,16 +57,16 @@
   )
 )
 
-;; @desc get-owner
+;; @desc get-contract-owner
 ;; @returns principal
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-;; @desc set-owner
+;; @desc set-contract-owner
 ;; @param new-contract-owner; new CONTRACT-OWNER
 ;; @returns (response bool uint)
-(define-public (set-owner (new-contract-owner principal))
+(define-public (set-contract-owner (new-contract-owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (var-set CONTRACT-OWNER new-contract-owner)

--- a/clarity/contracts/equations/yield-token-equation.clar
+++ b/clarity/contracts/equations/yield-token-equation.clar
@@ -58,16 +58,16 @@
   )
 )
 
-;; @desc get-owner
+;; @desc get-contract-owner
 ;; @returns principal
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-;; @desc set-owner
+;; @desc set-contract-owner
 ;; @param new-contract-owner; new CONTRACT-OWNER
 ;; @returns (response bool uint)
-(define-public (set-owner (new-contract-owner principal))
+(define-public (set-contract-owner (new-contract-owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (var-set CONTRACT-OWNER new-contract-owner)

--- a/clarity/contracts/faucet.clar
+++ b/clarity/contracts/faucet.clar
@@ -24,11 +24,11 @@
 ;; default max-use is once
 (define-data-var max-use uint u1)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/key-token/key-usda-wbtc.clar
+++ b/clarity/contracts/key-token/key-usda-wbtc.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/key-token/key-usda-wstx.clar
+++ b/clarity/contracts/key-token/key-usda-wstx.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/key-token/key-wbtc-usda.clar
+++ b/clarity/contracts/key-token/key-wbtc-usda.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/key-token/key-wbtc-wbtc.clar
+++ b/clarity/contracts/key-token/key-wbtc-wbtc.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/lottery-tokens/lottery-t-alex.clar
+++ b/clarity/contracts/lottery-tokens/lottery-t-alex.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool-token/fwp-wstx-usda-50-50.clar
+++ b/clarity/contracts/pool-token/fwp-wstx-usda-50-50.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool-token/fwp-wstx-wbtc-50-50.clar
+++ b/clarity/contracts/pool-token/fwp-wstx-wbtc-50-50.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool-token/lbp-alex-usda-90-10.clar
+++ b/clarity/contracts/pool-token/lbp-alex-usda-90-10.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool-token/test-pool-token.clar
+++ b/clarity/contracts/pool-token/test-pool-token.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool-token/ytp-yield-usda.clar
+++ b/clarity/contracts/pool-token/ytp-yield-usda.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/pool-token/ytp-yield-wbtc.clar
+++ b/clarity/contracts/pool-token/ytp-yield-wbtc.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/pool/alex-launchpad.clar
+++ b/clarity/contracts/pool/alex-launchpad.clar
@@ -29,11 +29,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/alex-reserve-pool.clar
+++ b/clarity/contracts/pool/alex-reserve-pool.clar
@@ -21,11 +21,11 @@
 (define-data-var CONTRACT-OWNER principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/collateral-rebalancing-pool.clar
+++ b/clarity/contracts/pool/collateral-rebalancing-pool.clar
@@ -35,11 +35,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/fixed-weight-pool.clar
+++ b/clarity/contracts/pool/fixed-weight-pool.clar
@@ -25,11 +25,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/futures-pool.clar
+++ b/clarity/contracts/pool/futures-pool.clar
@@ -20,11 +20,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/liquidity-bootstrapping-pool.clar
+++ b/clarity/contracts/pool/liquidity-bootstrapping-pool.clar
@@ -25,11 +25,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/yield-collateral-rebalancing-pool.clar
+++ b/clarity/contracts/pool/yield-collateral-rebalancing-pool.clar
@@ -36,11 +36,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/pool/yield-token-pool.clar
+++ b/clarity/contracts/pool/yield-token-pool.clar
@@ -31,11 +31,11 @@
 
 (define-data-var CONTRACT-OWNER principal tx-sender)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/staked-token/staked-alex.clar
+++ b/clarity/contracts/staked-token/staked-alex.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/token/token-alex.clar
+++ b/clarity/contracts/token/token-alex.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/token/token-t-alex.clar
+++ b/clarity/contracts/token/token-t-alex.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/token/token-usda.clar
+++ b/clarity/contracts/token/token-usda.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/token/token-wbtc.clar
+++ b/clarity/contracts/token/token-wbtc.clar
@@ -11,11 +11,11 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED (err u1000))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/traits/trait-ownable.clar
+++ b/clarity/contracts/traits/trait-ownable.clar
@@ -1,6 +1,6 @@
 (define-trait ownable-trait
 	(
-		(get-owner () (response principal uint))
-		(set-owner (principal) (response bool uint))
+		(get-contract-owner () (response principal uint))
+		(set-contract-owner (principal) (response bool uint))
 	)
 )

--- a/clarity/contracts/wrapped-token/token-wstx.clar
+++ b/clarity/contracts/wrapped-token/token-wstx.clar
@@ -11,11 +11,11 @@
 (define-constant ERR-MINT-FAILED (err u6002))
 (define-constant ERR-BURN-FAILED (err u6003))
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get CONTRACT-OWNER))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get CONTRACT-OWNER)) ERR-NOT-AUTHORIZED)
     (ok (var-set CONTRACT-OWNER owner))

--- a/clarity/contracts/yield-token/yield-usda.clar
+++ b/clarity/contracts/yield-token/yield-usda.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/contracts/yield-token/yield-wbtc.clar
+++ b/clarity/contracts/yield-token/yield-wbtc.clar
@@ -14,11 +14,11 @@
 (define-data-var contract-owner principal tx-sender)
 (define-map approved-contracts principal bool)
 
-(define-read-only (get-owner)
+(define-read-only (get-contract-owner)
   (ok (var-get contract-owner))
 )
 
-(define-public (set-owner (owner principal))
+(define-public (set-contract-owner (owner principal))
   (begin
     (asserts! (is-eq contract-caller (var-get contract-owner)) ERR-NOT-AUTHORIZED)
     (ok (var-set contract-owner owner))

--- a/clarity/tests/futures-pool_test.ts
+++ b/clarity/tests/futures-pool_test.ts
@@ -1,8 +1,8 @@
-import {Clarinet, Tx, Chain, Account, types} from "https://deno.land/x/clarinet@v0.14.0/index.ts";
+import { Clarinet, Tx, Chain, Account, types } from "https://deno.land/x/clarinet@v0.14.0/index.ts";
 import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
 import { FuturesPool } from "./models/alex-tests-futures-pool.ts";
 import { ALEXToken } from "./models/alex-tests-tokens.ts";
-  
+
 const ONE_8 = 100000000
 
 const alexTokenAddress = "ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.token-t-alex";
@@ -10,18 +10,18 @@ const stakedAlexAddress = "ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.staked-alex
 const ACTIVATION_DELAY = 150
 
 Clarinet.test({
-    name: "STACKING POOL: Ensure that set-owner can only be called by contract owner",
+    name: "STACKING POOL: Ensure that set-contract-owner can only be called by contract owner",
     async fn(chain: Chain, accounts: Map<string, Account>) {
         var notContractOwner = accounts.get("wallet_1")!;
         var wallet_2 = accounts.get("wallet_2")!;
 
         let block = chain.mineBlock([
-        Tx.contractCall(
-            "futures-pool",
-            "set-owner",
-            [types.principal(wallet_2.address)],
-            notContractOwner.address
-        ),
+            Tx.contractCall(
+                "futures-pool",
+                "set-contract-owner",
+                [types.principal(wallet_2.address)],
+                notContractOwner.address
+            ),
         ]);
 
         block.receipts[0].result.expectErr().expectUint(1000);
@@ -30,7 +30,7 @@ Clarinet.test({
 
 Clarinet.test({
     name: "STACKING POOL: Ensure that create-pool can only be called by contract owner",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         var notContractOwner = accounts.get("wallet_1")!;
         var futuresPool = new FuturesPool(chain)
         const futuresPoolBlock = chain.mineBlock([
@@ -43,11 +43,11 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that register-user can only be called by valid token"
 Clarinet.test({
     name: "STACKING POOL: Ensure that register-user can only be called by valid token",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get("deployer")!;
         const futuresPool = new FuturesPool(chain)
-        const rewardCycles: Array<string> = ["u1","u2","u3","u4","u5","u6","u7","u8","u9","u10","u11","u12","u13","u14","u15","u16","u17","u18","u19","u20","u21","u22","u23","u24","u25","u26","u27","u28","u29","u30","u31","u32"]
-        
+        const rewardCycles: Array<string> = ["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u18", "u19", "u20", "u21", "u22", "u23", "u24", "u25", "u26", "u27", "u28", "u29", "u30", "u31", "u32"]
+
         const futuresPoolBlock = chain.mineBlock([
             futuresPool.createPool(deployer, alexTokenAddress, alexTokenAddress, rewardCycles, stakedAlexAddress),
         ])
@@ -58,11 +58,11 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that register-user can only register new users"
 Clarinet.test({
     name: "STACKING POOL: Ensure that register-user can only register new users",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         var deployer = accounts.get("deployer")!;
         const otherUser = accounts.get("wallet_2")!;
         const futuresPool = new FuturesPool(chain);
-        const rewardCycles: Array<string> = ["u1","u2","u3","u4","u5","u6","u7","u8","u9","u10","u11","u12","u13","u14","u15","u16","u17","u18","u19","u20","u21","u22","u23","u24","u25","u26","u27","u28","u29","u30","u31","u32"]
+        const rewardCycles: Array<string> = ["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u18", "u19", "u20", "u21", "u22", "u23", "u24", "u25", "u26", "u27", "u28", "u29", "u30", "u31", "u32"]
 
         // setting up a working stacking pool
         const setupBlock = chain.mineBlock([
@@ -89,12 +89,12 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that stacking is available when adding to position"
 Clarinet.test({
     name: "STACKING POOL: Ensure that stacking is available when adding to position",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get("deployer")!;
         const futuresPool = new FuturesPool(chain)
-        const rewardCycles: Array<string> = ["u1","u2","u3","u4","u5","u6","u7","u8","u9","u10","u11","u12","u13","u14","u15","u16","u17","u18","u19","u20","u21","u22","u23","u24","u25","u26","u27","u28","u29","u30","u31","u32"]
+        const rewardCycles: Array<string> = ["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u18", "u19", "u20", "u21", "u22", "u23", "u24", "u25", "u26", "u27", "u28", "u29", "u30", "u31", "u32"]
         const startCycle = 1;
-        const dx = 50000*ONE_8
+        const dx = 50000 * ONE_8
 
         // setting up a working stacking pool
         const setupBlock = chain.mineBlock([
@@ -116,10 +116,10 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that stacking is not in progress when adding to position"
 Clarinet.test({
     name: "STACKING POOL: Ensure that stacking is not in progress when adding to position",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get("deployer")!;
         const futuresPool = new FuturesPool(chain)
-        const dx = 50000*ONE_8
+        const dx = 50000 * ONE_8
 
         // setting up a working stacking pool
         const setupBlock = chain.mineBlock([
@@ -144,13 +144,13 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that add-to-position works on a valid pool"
 Clarinet.test({
     name: "STACKING POOL: Ensure that add-to-position works on a valid pool",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get("deployer")!;
         const wallet_2 = accounts.get("wallet_2")!;
         const futuresPool = new FuturesPool(chain)
         const alexToken = new ALEXToken(chain, deployer)
-        const rewardCycles: Array<string> = ["u1","u2","u3","u4","u5","u6","u7","u8","u9","u10","u11","u12","u13","u14","u15","u16","u17","u18","u19","u20","u21","u22","u23","u24","u25","u26","u27","u28","u29","u30","u31","u32"]
-        const dx = 200*ONE_8
+        const rewardCycles: Array<string> = ["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u18", "u19", "u20", "u21", "u22", "u23", "u24", "u25", "u26", "u27", "u28", "u29", "u30", "u31", "u32"]
+        const dx = 200 * ONE_8
 
         alexToken.mintFixed(deployer, wallet_2.address, 200 * ONE_8);
 
@@ -169,7 +169,7 @@ Clarinet.test({
             futuresPool.createPool(deployer, alexTokenAddress, alexTokenAddress, rewardCycles, stakedAlexAddress),
             futuresPool.addToPosition(wallet_2, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, dx)
         ]);
-        futuresPoolBlock.receipts[0].result.expectOk().expectBool(true)    
+        futuresPoolBlock.receipts[0].result.expectOk().expectBool(true)
         futuresPoolBlock.receipts[1].result.expectOk().expectBool(true);
     }
 })
@@ -177,13 +177,13 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that reduce-position is called when stacking is not in progress"
 Clarinet.test({
     name: "STACKING POOL: Ensure that reduce-position is called when stacking is not in progress",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get("deployer")!;
         const wallet_1 = accounts.get("wallet_1")!;
         const futuresPool = new FuturesPool(chain)
         const alexToken = new ALEXToken(chain, deployer)
-        const rewardCycles: Array<string> = ["u1","u2","u3","u4","u5","u6","u7","u8","u9","u10","u11","u12","u13","u14","u15","u16","u17","u18","u19","u20","u21","u22","u23","u24","u25","u26","u27","u28","u29","u30","u31","u32"]
-        
+        const rewardCycles: Array<string> = ["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u18", "u19", "u20", "u21", "u22", "u23", "u24", "u25", "u26", "u27", "u28", "u29", "u30", "u31", "u32"]
+
         //mint alex tokens
         alexToken.mintFixed(deployer, wallet_1.address, 200 * ONE_8);
 
@@ -200,10 +200,10 @@ Clarinet.test({
         // creating a new pool
         const futuresPoolBlock = chain.mineBlock([
             futuresPool.createPool(deployer, alexTokenAddress, alexTokenAddress, ["u1"], stakedAlexAddress),
-            futuresPool.addToPosition(wallet_1, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, 200*ONE_8),
+            futuresPool.addToPosition(wallet_1, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, 200 * ONE_8),
             futuresPool.reducePosition(wallet_1, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, 10)
         ]);
-        futuresPoolBlock.receipts[0].result.expectOk().expectBool(true)    
+        futuresPoolBlock.receipts[0].result.expectOk().expectBool(true)
         futuresPoolBlock.receipts[1].result.expectOk().expectBool(true);
         futuresPoolBlock.receipts[2].result.expectErr().expectUint(2018); //ERR-STACKING-IN-PROGRESS
     }
@@ -212,13 +212,13 @@ Clarinet.test({
 // name: "STACKING POOL: Ensure that deployer can create-pool, add-to-position and reduce-to-position"
 Clarinet.test({
     name: "STACKING POOL: Ensure that deployer can create-pool, add-to-position and reduce-to-position",
-    async fn(chain: Chain, accounts: Map<string, Account>){
+    async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get("deployer")!;
         const wallet_1 = accounts.get("wallet_1")!;
         const futuresPool = new FuturesPool(chain)
         const alexToken = new ALEXToken(chain, deployer)
-        const rewardCycles: Array<string> = ["u1","u2","u3","u4","u5","u6","u7","u8","u9","u10","u11","u12","u13","u14","u15","u16","u17","u18","u19","u20","u21","u22","u23","u24","u25","u26","u27","u28","u29","u30","u31","u32"]
-        
+        const rewardCycles: Array<string> = ["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u18", "u19", "u20", "u21", "u22", "u23", "u24", "u25", "u26", "u27", "u28", "u29", "u30", "u31", "u32"]
+
         //mint alex tokens
         alexToken.mintFixed(deployer, deployer.address, 200 * ONE_8);
         alexToken.mintFixed(deployer, wallet_1.address, 200 * ONE_8);
@@ -238,9 +238,9 @@ Clarinet.test({
         // creating a new pool
         const futuresPoolBlock = chain.mineBlock([
             futuresPool.createPool(deployer, alexTokenAddress, alexTokenAddress, rewardCycles, stakedAlexAddress),
-            futuresPool.addToPosition(wallet_1, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, 200*ONE_8),
+            futuresPool.addToPosition(wallet_1, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, 200 * ONE_8),
         ]);
-        futuresPoolBlock.receipts[0].result.expectOk().expectBool(true)    
+        futuresPoolBlock.receipts[0].result.expectOk().expectBool(true)
         futuresPoolBlock.receipts[1].result.expectOk().expectBool(true);
 
         // console.log(futuresPool.getRewardCycleLength(deployer).result)
@@ -257,7 +257,7 @@ Clarinet.test({
             futuresPool.reducePosition(wallet_1, alexTokenAddress, alexTokenAddress, 1, stakedAlexAddress, ONE_8)
         ]);
 
-        let tuple:any = reducePosBlock.receipts[0].result.expectOk().expectTuple();
+        let tuple: any = reducePosBlock.receipts[0].result.expectOk().expectTuple();
         tuple['staked-token'].expectUint(200e8);
         tuple['reward-token'].expectUint(32 * ONE_8);
     }

--- a/clarity/tests/models/alex-tests-launchpad.ts
+++ b/clarity/tests/models/alex-tests-launchpad.ts
@@ -4,7 +4,7 @@ import {
     Tx,
     ReadOnlyFn,
     types,
-  } from "https://deno.land/x/clarinet@v0.14.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.14.0/index.ts";
 
 class ALEXLaunchpad {
     chain: Chain;
@@ -15,55 +15,55 @@ class ALEXLaunchpad {
         this.deployer = deployer;
     }
 
-    createPool(sender:Account, token: string, ticket: string, feeToAddress: string, amountPerTicket: number, wstxPerTicketInFixed: number, registrationStart: number, registrationEnd: number, claimEnd:number, activationThreshold: number) {
+    createPool(sender: Account, token: string, ticket: string, feeToAddress: string, amountPerTicket: number, wstxPerTicketInFixed: number, registrationStart: number, registrationEnd: number, claimEnd: number, activationThreshold: number) {
         let block = this.chain.mineBlock([
             Tx.contractCall("alex-launchpad", "create-pool", [
-                    types.principal(token),
-                    types.principal(ticket),
-                    types.principal(feeToAddress),
-                    types.uint(amountPerTicket),
-                    types.uint(wstxPerTicketInFixed),
-                    types.uint(registrationStart),
-                    types.uint(registrationEnd),
-                    types.uint(claimEnd),
-                    types.uint(activationThreshold),
-                ],
+                types.principal(token),
+                types.principal(ticket),
+                types.principal(feeToAddress),
+                types.uint(amountPerTicket),
+                types.uint(wstxPerTicketInFixed),
+                types.uint(registrationStart),
+                types.uint(registrationEnd),
+                types.uint(claimEnd),
+                types.uint(activationThreshold),
+            ],
                 sender.address
             ),
         ]);
         return block;
     }
-    
-    addToPosition(sender:Account, token: string, tickets: number ) {
+
+    addToPosition(sender: Account, token: string, tickets: number) {
         let block = this.chain.mineBlock([
             Tx.contractCall("alex-launchpad", "add-to-position", [
                 types.principal(token),
                 types.uint(tickets),
             ],
-            sender.address
-        ),
+                sender.address
+            ),
         ]);
         return block;
     }
 
-    register(sender:Account, token: string, ticketTrait: string, ticketAmount: number) {
+    register(sender: Account, token: string, ticketTrait: string, ticketAmount: number) {
         let block = this.chain.mineBlock([
             Tx.contractCall("alex-launchpad", "register", [
                 types.principal(token),
                 types.principal(ticketTrait),
                 types.uint(ticketAmount),
-                ],
+            ],
                 sender.address
             ),
         ]);
         return block.receipts[0].result;
     }
 
-    refund (sender: Account, tokenTrait: string) {
+    refund(sender: Account, tokenTrait: string) {
         let block = this.chain.mineBlock([
-            Tx.contractCall( "alex-launchpad", "refund", [
+            Tx.contractCall("alex-launchpad", "refund", [
                 types.principal(tokenTrait),
-                ],
+            ],
                 sender.address
             ),
         ]);
@@ -72,10 +72,10 @@ class ALEXLaunchpad {
 
     claim(sender: Account, tokenTrait: string, ticketTrait: string) {
         let block = this.chain.mineBlock([
-            Tx.contractCall( "alex-launchpad", "claim", [
+            Tx.contractCall("alex-launchpad", "claim", [
                 types.principal(tokenTrait),
                 types.principal(ticketTrait),
-                ],
+            ],
                 sender.address
             ),
         ]);
@@ -85,10 +85,10 @@ class ALEXLaunchpad {
     getRegistrationStart(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
-            "get-registration-start", 
+            "get-registration-start",
             [
                 types.principal(token)
-            ], 
+            ],
             this.deployer.address
         );
     }
@@ -96,10 +96,10 @@ class ALEXLaunchpad {
     isListingCompleted(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
-            "is-listing-completed", 
+            "is-listing-completed",
             [
                 types.principal(token)
-            ], 
+            ],
             this.deployer.address
         );
     }
@@ -107,10 +107,10 @@ class ALEXLaunchpad {
     isListingActivated(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
-            "is-listing-activated", 
+            "is-listing-activated",
             [
                 types.principal(token)
-            ], 
+            ],
             this.deployer.address
         );
     }
@@ -118,19 +118,19 @@ class ALEXLaunchpad {
     getActivationBlock(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
-            "get-activation-block", 
+            "get-activation-block",
             [
                 types.principal(token)
-            ], 
+            ],
             this.deployer.address
         );
     }
-    
-    getOwner():ReadOnlyFn {
+
+    getOwner(): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
-            "alex-launchpad", 
-            "get-owner", 
-            [], 
+            "alex-launchpad",
+            "get-contract-owner",
+            [],
             this.deployer.address
         );
     }
@@ -139,7 +139,7 @@ class ALEXLaunchpad {
         let block = this.chain.mineBlock([
             Tx.contractCall(
                 "alex-launchpad",
-                "set-owner",
+                "set-contract-owner",
                 [
                     types.principal(owner)
                 ],
@@ -149,7 +149,7 @@ class ALEXLaunchpad {
         return block.receipts[0].result;
     }
 
-    getTokenDetails(token: string): ReadOnlyFn{
+    getTokenDetails(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
             "get-token-details",
@@ -160,7 +160,7 @@ class ALEXLaunchpad {
         )
     }
 
-    getSubscriberAtTokenOrDefault(token: string, userId: number): ReadOnlyFn{
+    getSubscriberAtTokenOrDefault(token: string, userId: number): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
             "get-subscriber-at-token-or-default",
@@ -172,7 +172,7 @@ class ALEXLaunchpad {
         )
     }
 
-    getActivationThreshold(token: string): ReadOnlyFn{
+    getActivationThreshold(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
             "get-activation-threshold",
@@ -182,8 +182,8 @@ class ALEXLaunchpad {
             this.deployer.address
         )
     }
-    
-    getRegisteredUsersNonce(token: string): ReadOnlyFn{
+
+    getRegisteredUsersNonce(token: string): ReadOnlyFn {
         return this.chain.callReadOnlyFn(
             "alex-launchpad",
             "get-registered-users-nonce",


### PR DESCRIPTION
Rename `ownable-trait` members to be less ambiguous. I first formulated it without a lot of thought, and later it struck me just how vague `get-owner` actually is, get the owner of what? The contract? A token? Something else? What is worse, there is already a collision with an existing SIP; namely, [SIP009](https://github.com/stacksgov/sips/blob/main/sips/sip-009/sip-009-nft-standard.md#owner). We have used `ownable-trait` across a few different projects and I intend to submit it as a simple SIP at some point. I have started using `get-contract-owner` and `set-contract-owner` in lieu of the old one in this repo. Let us also adopt it here.

Old:
```clojure
(define-trait ownable-trait
	(
		(get-owner () (response principal uint))
		(set-owner (principal) (response bool uint))
	)
)
```

New:
```clojure
(define-trait ownable-trait
	(
		(get-contract-owner () (response principal uint))
		(set-contract-owner (principal) (response bool uint))
	)
)
```

`clarinet test` passes and I assume there are no interface components for these functions.